### PR TITLE
updated build script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,4 @@
 target/
 
 # Process Files
-server.PID
+*.PID

--- a/Makefile
+++ b/Makefile
@@ -19,15 +19,13 @@ run: $(TARGET)
 	$(JAVA) -jar $(TARGET)
 
 
-# Rebuilds & runs the Soundboard against a dummy server.
-.PHONY: debug
-debug: $(DUMMY)
-	$(MAVEN) -f $(SOUNDBOARD) clean
-	$(JAVA) -jar $(DUMMY) & echo $$! > server.PID&
-	$(MAKE) run
+.PHONY: start_dummy
+start_dummy: $(DUMMY)
 	$(MAKE) shutdown_dummy
+	$(JAVA) -jar $(DUMMY) & echo $$! > server.PID&
 
 
+.PHONY: shutdown_dummy
 shutdown_dummy:
 	@if test -f "server.PID";then\
 		echo "Checking status of dummy server..";\
@@ -38,6 +36,15 @@ shutdown_dummy:
 		echo "Removing PID cache file..";\
 		rm -f server.PID;\
 	fi;
+
+
+# Rebuilds & runs the Soundboard against a dummy server.
+.PHONY: debug
+debug:
+	$(MAVEN) -f $(SOUNDBOARD) clean
+	$(MAKE) start_dummy
+	$(MAKE) run
+	$(MAKE) shutdown_dummy
 
 
 .PHONY: clean


### PR DESCRIPTION
- added rules for starting and stopping the dummy server. 
- starting the dummy server shall first try kill the process in the pid file, then start a new process.