### PR TITLE
Catalogue Editor Model

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,15 @@
+SHELL := /bin/bash
+# Executables
 JAVA = java
 MAVEN = mvn
+# Artifact IDs
 SOUNDBOARD = soundboard
 SERVER = server
+# Compile Targets
 TARGET = $(SOUNDBOARD)/target/soundboard-*-jar-with-dependencies.jar
 DUMMY = $(SERVER)/target/server-*-jar-with-dependencies.jar
+# Dev Folders
+RELEASES = RELEASES/
 
 
 $(TARGET):
@@ -14,25 +20,30 @@ $(DUMMY):
 	$(MAVEN) package --projects $(SERVER)
 
 
+$(RELEASES):
+	@mkdir $(RELEASES) & echo "Created release directory @ $(RELEASES)."
+
+
 .PHONY: run
 run: ARGS?=
 run: $(TARGET)
 	$(JAVA) -jar $(TARGET) $(ARGS)
 
 
-.PHONY: start_dummy
-start_dummy: ARGS?=
-start_dummy: $(DUMMY)
-	$(MAKE) shutdown_dummy
-	$(JAVA) -jar $(DUMMY) $(ARGS) & echo $$! > server.PID&
+.PHONY: run_dummy
+run_dummy: ARGS?=
+run_dummy: $(DUMMY)
+	@$(MAKE) stop_dummy
+	@echo "Starting dummy server..."
+	@$(JAVA) -jar $(DUMMY) $(ARGS) & echo $$! > server.PID&
 
 
-.PHONY: shutdown_dummy
-shutdown_dummy:
+.PHONY: stop_dummy
+stop_dummy:
 	@if test -f "server.PID";then\
 		echo "Checking status of dummy server..";\
 		if ps -p `cat server.PID`;then\
-			echo "Shutting down running dummy server process..";\
+			echo "Shutting down running dummy server process...";\
 			kill `cat server.PID`;\
 		fi;\
 		echo "Removing PID cache file..";\
@@ -41,14 +52,53 @@ shutdown_dummy:
 
 
 # Runs a clean snapshot of the Soundboard against a dummy server instance.
-.PHONY: debug
-debug:
-	$(MAVEN) clean compile exec:java --projects $(SOUNDBOARD)
-	$(MAKE) start_dummy
-	$(MAKE) shutdown_dummy
+.PHONY: snapshot
+snapshot:
+	@echo "Rebuilding $(SOUNDBOARD)..."
+	@$(MAVEN) clean compile exec:java --projects $(SOUNDBOARD)
+	@$(MAKE) run_dummy
+	@$(MAKE) stop_dummy
+
+
+.PHONY: clean_releases
+clean_releases: $(RELEASES)
+	@if test -d $(RELEASES);then\
+		if compgen -G "$(RELEASES)*.jar" > /dev/null; then\
+			echo "Removing jars found in $(RELEASES).";\
+			rm $(RELEASES)*.jar;\
+		fi;\
+	fi;
 
 
 .PHONY: clean
 clean:
-	$(MAKE) shutdown_dummy
-	$(MAVEN) clean
+	@$(MAKE) stop_dummy
+	@echo "Removing compiled code and artifacts..."
+	@$(MAVEN) clean
+	@$(MAKE) clean_releases
+
+
+.PHONY: version
+version: v?=
+version:
+	@if test -z "$$v"; then\
+		echo "Rule requires 'v=' arg to specify target version.";\
+		exit 1;\
+	fi;
+	@echo "Updating $(SOUNDBOARD)'s version..."
+	@$(MAVEN) versions:set -DnewVersion=$(v) --projects $(SOUNDBOARD)/pom.xml > /dev/null
+
+
+.PHONY: release
+release: v?=
+release: $(RELEASES)
+	@if ! test -z "$$v"; then\
+		echo "Versioning was specified.";\
+		$(MAKE) version v=$(v);\
+	fi;
+	@echo "Repackaging $(SOUNDBOARD) jar..."
+	@$(MAVEN) clean package --projects $(SOUNDBOARD)  > /dev/null
+	@echo "Checking for jars in $(RELEASES).."
+	@$(MAKE) clean_releases
+	@echo "Copying latest $(SOUNDBOARD) jar to $(RELEASES).."
+	@cp $(TARGET) $(RELEASES)

--- a/Makefile
+++ b/Makefile
@@ -7,11 +7,11 @@ DUMMY = $(SERVER)/target/server-*-jar-with-dependencies.jar
 
 
 $(TARGET):
-	$(MAVEN) -f $(SOUNDBOARD) package
+	$(MAVEN) package --projects $(SOUNDBOARD)
 
 
 $(DUMMY):
-	$(MAVEN) -f $(SERVER) package
+	$(MAVEN) package --projects $(SERVER)
 
 
 .PHONY: run
@@ -20,9 +20,9 @@ run: $(TARGET)
 	$(JAVA) -jar $(TARGET) $(ARGS)
 
 
-.PHONY: dummy
-dummy: ARGS?=
-dummy: $(DUMMY)
+.PHONY: start_dummy
+start_dummy: ARGS?=
+start_dummy: $(DUMMY)
 	$(MAKE) shutdown_dummy
 	$(JAVA) -jar $(DUMMY) $(ARGS) & echo $$! > server.PID&
 
@@ -40,17 +40,15 @@ shutdown_dummy:
 	fi;
 
 
-# Rebuilds & runs the Soundboard against a dummy server.
+# Runs a clean snapshot of the Soundboard against a dummy server instance.
 .PHONY: debug
 debug:
-	$(MAVEN) -f $(SOUNDBOARD) clean
-	$(MAKE) dummy
-	$(MAKE) run
+	$(MAVEN) clean compile exec:java --projects $(SOUNDBOARD)
+	$(MAKE) start_dummy
 	$(MAKE) shutdown_dummy
 
 
 .PHONY: clean
 clean:
 	$(MAKE) shutdown_dummy
-	$(MAVEN) -f $(SOUNDBOARD) clean
-	$(MAVEN) -f $(SERVER) clean
+	$(MAVEN) clean

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>za.co.lynx</groupId>
+    <artifactId>companion</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>pom</packaging>
+
+    <modules>
+        <module>server</module>
+        <module>soundboard</module>
+    </modules>
+
+    <properties>
+        <maven.compiler.source>20</maven.compiler.source>
+        <maven.compiler.target>20</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>info.picocli</groupId>
+            <artifactId>picocli</artifactId>
+            <version>4.7.5</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.10.0</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -4,32 +4,19 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>za.co.lynx</groupId>
+    <parent>
+        <groupId>za.co.lynx</groupId>
+        <artifactId>companion</artifactId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+
     <artifactId>server</artifactId>
-    <version>0.0.0-SNAPSHOT</version>
+    <version>1.0</version>
     <packaging>jar</packaging>
 
     <properties>
-        <maven.compiler.source>20</maven.compiler.source>
-        <maven.compiler.target>20</maven.compiler.target>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <exec.mainClass>SingleServer</exec.mainClass>
     </properties>
-
-    <dependencies>
-        <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter</artifactId>
-            <version>5.10.0</version>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>info.picocli</groupId>
-            <artifactId>picocli</artifactId>
-            <version>4.7.5</version>
-        </dependency>
-
-    </dependencies>
 
     <build>
         <plugins>
@@ -58,16 +45,6 @@
                     </execution>
                 </executions>
             </plugin>
-
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>exec-maven-plugin</artifactId>
-                <version>3.0.0</version>
-                <configuration>
-                    <mainClass>SingleServer</mainClass>
-                </configuration>
-            </plugin>
-
         </plugins>
     </build>
 

--- a/soundboard/pom.xml
+++ b/soundboard/pom.xml
@@ -17,6 +17,13 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.10.0</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
             <version>2.15.2</version>

--- a/soundboard/pom.xml
+++ b/soundboard/pom.xml
@@ -4,15 +4,18 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>za.co.lynx</groupId>
+    <parent>
+        <groupId>za.co.lynx</groupId>
+        <artifactId>companion</artifactId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+
     <artifactId>soundboard</artifactId>
     <version>1.0.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <properties>
-        <maven.compiler.source>20</maven.compiler.source>
-        <maven.compiler.target>20</maven.compiler.target>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <exec.mainClass>soundboard.App</exec.mainClass>
     </properties>
 
     <dependencies>
@@ -33,12 +36,6 @@
             <groupId>com.formdev</groupId>
             <artifactId>flatlaf</artifactId>
             <version>3.2</version>
-        </dependency>
-
-        <dependency>
-            <groupId>info.picocli</groupId>
-            <artifactId>picocli</artifactId>
-            <version>4.7.5</version>
         </dependency>
 
     </dependencies>
@@ -69,16 +66,6 @@
                     </execution>
                 </executions>
             </plugin>
-
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>exec-maven-plugin</artifactId>
-                <version>3.0.0</version>
-                <configuration>
-                    <mainClass>soundboard.App</mainClass>
-                </configuration>
-            </plugin>
-
         </plugins>
     </build>
 

--- a/soundboard/src/main/java/editor/model/EditableCatalogue.java
+++ b/soundboard/src/main/java/editor/model/EditableCatalogue.java
@@ -1,0 +1,65 @@
+package editor.model;
+
+import soundboard.model.catalogue.Catalogue;
+import soundboard.model.catalogue.Group;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Editable Catalogue that can track changes (edits), without mutating or cloning
+ * the original Catalogue directly. Allows changes to be rolled back safely.
+ *
+ * @see Catalogue
+ */
+public class EditableCatalogue {
+
+    private final Catalogue catalogue;
+    private final List<Group> markedForRemoval;
+    private final List<Group> recentlyAdded;
+
+    /**
+     * Wraps a Catalogue, creating an Editable Catalogue that can tracks changes
+     * to the original, without mutating it.
+     *
+     * @param catalogue mutable Catalogue to track changes for.
+     */
+    public EditableCatalogue(Catalogue catalogue) {
+        this.catalogue = catalogue;
+        markedForRemoval = new ArrayList<>();
+        recentlyAdded = new ArrayList<>();
+    }
+
+    public void addGroup(Group group) {
+        recentlyAdded.add(group);
+        markedForRemoval.remove(group);
+    }
+
+    public void removeGroup(Group group) {
+        markedForRemoval.add(group);
+        recentlyAdded.remove(group);
+    }
+
+    public boolean isRecentlyAdded(Group group) {
+        return recentlyAdded.contains(group);
+    }
+
+    public boolean isMarkedForRemoval(Group group) {
+        return markedForRemoval.contains(group);
+    }
+
+    /**
+     * Commits changes to the Catalogue. This action is final, and will mutate the original
+     * Catalogue.
+     */
+    public void saveChanges() {
+        markedForRemoval.forEach(catalogue::remove);
+        catalogue.addAll(recentlyAdded);
+        clearChanges();
+    }
+
+    public void clearChanges() {
+        markedForRemoval.clear();
+        recentlyAdded.clear();
+    }
+}

--- a/soundboard/src/main/java/editor/model/EditableCatalogue.java
+++ b/soundboard/src/main/java/editor/model/EditableCatalogue.java
@@ -32,12 +32,18 @@ public class EditableCatalogue {
 
     public void addGroup(Group group) {
         recentlyAdded.add(group);
-        markedForRemoval.remove(group);
+    }
+
+    public void undoAddGroup(Group group) {
+        recentlyAdded.remove(group);
     }
 
     public void removeGroup(Group group) {
         markedForRemoval.add(group);
-        recentlyAdded.remove(group);
+    }
+
+    public void undoRemoveGroup(Group group) {
+        markedForRemoval.remove(group);
     }
 
     public boolean isRecentlyAdded(Group group) {

--- a/soundboard/src/main/java/editor/model/EditableGroup.java
+++ b/soundboard/src/main/java/editor/model/EditableGroup.java
@@ -1,0 +1,73 @@
+package editor.model;
+
+import soundboard.model.catalogue.Group;
+import soundboard.model.catalogue.Playlist;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Editable Group that can track changes (edits), without mutating or cloning
+ * the original Group directly. Allows changes to be rolled back safely.
+ *
+ * @see Group
+ */
+public class EditableGroup {
+
+    private final Group group;
+    private final List<Playlist> markedForRemoval;
+    private final List<Playlist> recentlyAdded;
+    private String updatedName;
+
+    /**
+     * Wraps a Group, creating an Editable Group that can tracks changes
+     * to the original, without mutating it.
+     *
+     * @param group mutable Group to track changes for.
+     */
+    public EditableGroup(Group group) {
+        this.group = group;
+        markedForRemoval = new ArrayList<>();
+        recentlyAdded = new ArrayList<>();
+        updatedName = group.getName();
+    }
+
+    public void addPlaylist(Playlist playlist) {
+        recentlyAdded.add(playlist);
+        markedForRemoval.remove(playlist);
+    }
+
+    public void removePlaylist(Playlist playlist) {
+        markedForRemoval.add(playlist);
+        recentlyAdded.remove(playlist);
+    }
+
+    public void updateTitle(String title) {
+        updatedName = title;
+    }
+
+    public boolean isRecentlyAdded(Playlist playlist) {
+        return recentlyAdded.contains(playlist);
+    }
+
+    public boolean isMarkedForRemoval(Playlist playlist) {
+        return markedForRemoval.contains(playlist);
+    }
+
+    /**
+     * Commits changes to the Group. This action is final, and will mutate the original
+     * Group.
+     */
+    public void saveChanges() {
+        markedForRemoval.forEach(group::remove);
+        group.addAll(recentlyAdded);
+        if (!updatedName.isBlank()) group.setName(updatedName);
+        clearChanges();
+    }
+
+    public void clearChanges() {
+        markedForRemoval.clear();
+        recentlyAdded.clear();
+        updatedName = group.getName();
+    }
+}

--- a/soundboard/src/main/java/editor/model/EditableGroup.java
+++ b/soundboard/src/main/java/editor/model/EditableGroup.java
@@ -34,12 +34,18 @@ public class EditableGroup {
 
     public void addPlaylist(Playlist playlist) {
         recentlyAdded.add(playlist);
-        markedForRemoval.remove(playlist);
+    }
+
+    public void undoAddPlaylist(Playlist playlist) {
+        recentlyAdded.remove(playlist);
     }
 
     public void removePlaylist(Playlist playlist) {
         markedForRemoval.add(playlist);
-        recentlyAdded.remove(playlist);
+    }
+
+    public void undoRemovePlaylist(Playlist playlist) {
+        markedForRemoval.remove(playlist);
     }
 
     public void updateTitle(String title) {

--- a/soundboard/src/main/java/editor/model/EditablePlaylist.java
+++ b/soundboard/src/main/java/editor/model/EditablePlaylist.java
@@ -1,0 +1,72 @@
+package editor.model;
+
+import soundboard.model.catalogue.Playlist;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Editable Playlist that can track changes (edits), without mutating or cloning
+ * the original Playlist directly. Allows changes to be rolled back safely.
+ *
+ * @see Playlist
+ */
+public class EditablePlaylist {
+
+    private final Playlist playlist;
+    private final List<String> markedForRemoval;
+    private final List<String> recentlyAdded;
+    private String updatedTitle;
+
+    /**
+     * Wraps a Playlist, creating an Editable Playlist that can tracks changes
+     * to the original, without mutating it.
+     *
+     * @param playlist mutable Playlist to track changes for.
+     */
+    public EditablePlaylist(Playlist playlist) {
+        this.playlist = playlist;
+        markedForRemoval = new ArrayList<>();
+        recentlyAdded = new ArrayList<>();
+        updatedTitle = playlist.getTitle();
+    }
+
+    public void addSong(String song) {
+        recentlyAdded.add(song);
+        markedForRemoval.remove(song);
+    }
+
+    public void removeSong(String song) {
+        markedForRemoval.add(song);
+        recentlyAdded.remove(song);
+    }
+
+    public void updateTitle(String title) {
+        updatedTitle = title;
+    }
+
+    public boolean isRecentlyAdded(String song) {
+        return recentlyAdded.contains(song);
+    }
+
+    public boolean isMarkedForRemoval(String song) {
+        return markedForRemoval.contains(song);
+    }
+
+    /**
+     * Commits changes to the Playlist. This action is final, and will mutate the original
+     * Playlist.
+     */
+    public void saveChanges() {
+        markedForRemoval.forEach(playlist::remove);
+        playlist.addAll(recentlyAdded);
+        if (!updatedTitle.isBlank()) playlist.setTitle(updatedTitle);
+        clearChanges();
+    }
+
+    public void clearChanges() {
+        markedForRemoval.clear();
+        recentlyAdded.clear();
+        updatedTitle = playlist.getTitle();
+    }
+}

--- a/soundboard/src/main/java/editor/model/EditablePlaylist.java
+++ b/soundboard/src/main/java/editor/model/EditablePlaylist.java
@@ -33,12 +33,18 @@ public class EditablePlaylist {
 
     public void addSong(String song) {
         recentlyAdded.add(song);
-        markedForRemoval.remove(song);
+    }
+
+    public void undoAddSong(String song) {
+        recentlyAdded.remove(song);
     }
 
     public void removeSong(String song) {
         markedForRemoval.add(song);
-        recentlyAdded.remove(song);
+    }
+
+    public void undoRemoveSong(String song) {
+        markedForRemoval.remove(song);
     }
 
     public void updateTitle(String title) {

--- a/soundboard/src/main/java/editor/model/package-info.java
+++ b/soundboard/src/main/java/editor/model/package-info.java
@@ -1,0 +1,10 @@
+/**
+ * This package contains data model classes for the CatalogueEditor.
+ * <p>
+ * Each model is a wrapper of an existing Soundboard data model.
+ * The wrapper is needed to track changes (edits) made by the user on the CatalogueEditorView,
+ * without mutating the original (wrapped) data model, or needing to clone it.
+ * This allows changes made on the View to be rolled back safely.
+ * </p>
+ */
+package editor.model;

--- a/soundboard/src/main/java/soundboard/controller/catalogue/CatalogueController.java
+++ b/soundboard/src/main/java/soundboard/controller/catalogue/CatalogueController.java
@@ -5,6 +5,7 @@ import soundboard.model.catalogue.Catalogue;
 import soundboard.view.catalogue.CatalogueView;
 import soundboard.view.catalogue.GroupPanel;
 
+import javax.swing.*;
 import java.util.ArrayList;
 import java.util.Collection;
 
@@ -30,7 +31,7 @@ public class CatalogueController {
             GroupController controller = new GroupController(category, view);
             controller.load();
             controllers.add(controller);
-            tabbedPane.addTab(category.getName(), view);
+            tabbedPane.addTab(category.getName(), new JScrollPane(view));
         });
     }
 

--- a/soundboard/src/main/java/soundboard/model/Icons.java
+++ b/soundboard/src/main/java/soundboard/model/Icons.java
@@ -12,7 +12,7 @@ import java.net.URL;
  */
 public class Icons {
 
-    private static final int ICON_SIZE = 40;
+    public static final int ICON_SIZE = 40;
 
     private final Icon backIcon;
     private final Icon leaveIcon;

--- a/soundboard/src/main/java/soundboard/model/catalogue/Group.java
+++ b/soundboard/src/main/java/soundboard/model/catalogue/Group.java
@@ -11,7 +11,7 @@ public class Group extends ArrayList<Playlist> {
 
     private String name;
 
-    protected Group(String name) {
+    public Group(String name) {
         this.name = name;
     }
 

--- a/soundboard/src/main/java/soundboard/model/catalogue/Group.java
+++ b/soundboard/src/main/java/soundboard/model/catalogue/Group.java
@@ -9,7 +9,7 @@ import java.util.ArrayList;
  */
 public class Group extends ArrayList<Playlist> {
 
-    private final String name;
+    private String name;
 
     protected Group(String name) {
         this.name = name;
@@ -23,6 +23,10 @@ public class Group extends ArrayList<Playlist> {
 
     public String getName() {
         return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
     }
 
     /**

--- a/soundboard/src/main/java/soundboard/model/catalogue/Playlist.java
+++ b/soundboard/src/main/java/soundboard/model/catalogue/Playlist.java
@@ -2,15 +2,21 @@ package soundboard.model.catalogue;
 
 import com.fasterxml.jackson.databind.JsonNode;
 
-import java.util.HashSet;
+import java.util.ArrayList;
 
 /**
- * A Playlist represents a collection of songs.
- * Specifically, YouTube URL to songs for the discord bot to play from.
- * In the future, this may expand to additional services such as Deezer,
- * Spotify, or local songs.
+ * Represents a collection of songs.
+ * <br><br>
+ * Specifically, YouTube URLs to songs.
+ * These URLs are sent to the Bot service where they are used to retrieve
+ * audio sources to stream into a Discord Voice Channel.
+ * <br><br>
+ * In the future, the Bot may expand to additional services such as Deezer,
+ * Spotify, or local songs. In which case this Playlist will store
+ * Song objects that contain URLs and the name of the service the URL points to
+ * so that the Bot can know how to handle retrieving the audio source at that URL.
  */
-public class Playlist extends HashSet<String> {
+public class Playlist extends ArrayList<String> {
 
     private String title;
 
@@ -18,6 +24,10 @@ public class Playlist extends HashSet<String> {
         this.title = title;
     }
 
+    /**
+     * @param json Node representing a Playlist.
+     * @return Playlist constructed from the contents of a JSON node.
+     */
     public static Playlist fromJson(JsonNode json) {
         Playlist playlist = new Playlist(json.get("Title").asText());
         for (JsonNode song : json.get("Songs")) playlist.add(song.asText());

--- a/soundboard/src/main/java/soundboard/model/catalogue/Playlist.java
+++ b/soundboard/src/main/java/soundboard/model/catalogue/Playlist.java
@@ -14,7 +14,7 @@ public class Playlist extends HashSet<String> {
 
     private String title;
 
-    protected Playlist(String title) {
+    public Playlist(String title) {
         this.title = title;
     }
 

--- a/soundboard/src/main/java/soundboard/model/catalogue/Playlist.java
+++ b/soundboard/src/main/java/soundboard/model/catalogue/Playlist.java
@@ -12,7 +12,7 @@ import java.util.HashSet;
  */
 public class Playlist extends HashSet<String> {
 
-    private final String title;
+    private String title;
 
     protected Playlist(String title) {
         this.title = title;
@@ -26,6 +26,10 @@ public class Playlist extends HashSet<String> {
 
     public String getTitle() {
         return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
     }
 
     @Override

--- a/soundboard/src/main/java/soundboard/view/catalogue/PlaylistButton.java
+++ b/soundboard/src/main/java/soundboard/view/catalogue/PlaylistButton.java
@@ -1,13 +1,16 @@
 package soundboard.view.catalogue;
 
+import soundboard.model.Icons;
 import soundboard.model.catalogue.Playlist;
 
 import javax.swing.*;
+import java.awt.*;
 
 public class PlaylistButton extends JButton {
     public PlaylistButton(Playlist playlist) {
         super();
         this.setText(playlist.getTitle());
         this.setToolTipText(playlist.getTitle());
+        this.setPreferredSize(new Dimension(Icons.ICON_SIZE * 4, Icons.ICON_SIZE / 2));
     }
 }

--- a/soundboard/src/test/java/editor/model/EditableCatalogueTest.java
+++ b/soundboard/src/test/java/editor/model/EditableCatalogueTest.java
@@ -75,4 +75,29 @@ class EditableCatalogueTest {
         editableCatalogue.clearChanges();
         assertFalse(editableCatalogue.isMarkedForRemoval(group));
     }
+
+    @Test
+    void undoAddGroup() {
+        editableCatalogue.addGroup(group);
+        editableCatalogue.undoAddGroup(group);
+
+        assertFalse(editableCatalogue.isRecentlyAdded(group));
+        assertFalse(editableCatalogue.isMarkedForRemoval(group));
+
+        editableCatalogue.saveChanges();
+        assertEquals(0, catalogue.size());
+    }
+
+    @Test
+    void undoRemoveGroup() {
+        catalogue.add(group);
+
+        editableCatalogue.removeGroup(group);
+        editableCatalogue.undoRemoveGroup(group);
+        assertFalse(editableCatalogue.isRecentlyAdded(group));
+        assertFalse(editableCatalogue.isMarkedForRemoval(group));
+
+        editableCatalogue.saveChanges();
+        assertEquals(1, catalogue.size());
+    }
 }

--- a/soundboard/src/test/java/editor/model/EditableCatalogueTest.java
+++ b/soundboard/src/test/java/editor/model/EditableCatalogueTest.java
@@ -1,0 +1,75 @@
+package editor.model;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import soundboard.model.catalogue.Catalogue;
+import soundboard.model.catalogue.Group;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Confirm the EditableCatalogue only mutates the wrapped Catalogue.
+ * when requested.
+ *
+ * @see EditableCatalogue
+ * @see Catalogue
+ */
+class EditableCatalogueTest {
+
+    Catalogue catalogue;
+    EditableCatalogue editableCatalogue;
+    Group group;
+
+    @BeforeEach
+    void setUp() {
+        catalogue = new Catalogue();
+        editableCatalogue = new EditableCatalogue(catalogue);
+        group = new Group("mock");
+    }
+
+    @Test
+    void addGroup() {
+        editableCatalogue.addGroup(group);
+        assertEquals(0, catalogue.size());
+
+        editableCatalogue.saveChanges();
+        assertEquals(1, catalogue.size());
+
+        editableCatalogue.saveChanges();
+        assertEquals(1, catalogue.size(), "Changes should only be saved once.");
+    }
+
+    @Test
+    void removeGroup() {
+        catalogue.add(group);
+
+        editableCatalogue.removeGroup(group);
+        assertEquals(1, catalogue.size());
+
+        editableCatalogue.saveChanges();
+        assertEquals(0, catalogue.size());
+
+        editableCatalogue.saveChanges();
+        assertEquals(0, catalogue.size(), "Changes should only be saved once.");
+    }
+
+    @Test
+    void isRecentlyAdded() {
+        assertFalse(editableCatalogue.isRecentlyAdded(group));
+        editableCatalogue.addGroup(group);
+        assertTrue(editableCatalogue.isRecentlyAdded(group));
+
+        editableCatalogue.clearChanges();
+        assertFalse(editableCatalogue.isRecentlyAdded(group));
+    }
+
+    @Test
+    void isMarkedForRemoval() {
+        assertFalse(editableCatalogue.isMarkedForRemoval(group));
+        editableCatalogue.removeGroup(group);
+        assertTrue(editableCatalogue.isMarkedForRemoval(group));
+
+        editableCatalogue.clearChanges();
+        assertFalse(editableCatalogue.isMarkedForRemoval(group));
+    }
+}

--- a/soundboard/src/test/java/editor/model/EditableCatalogueTest.java
+++ b/soundboard/src/test/java/editor/model/EditableCatalogueTest.java
@@ -8,8 +8,11 @@ import soundboard.model.catalogue.Group;
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
- * Confirm the EditableCatalogue only mutates the wrapped Catalogue.
- * when requested.
+ * Confirm the EditableCatalogue only mutates the wrapped Catalogue when requested.
+ * <br><br>
+ * Implementation of EditableCatalogue is simple, and these tests are very basic.
+ * They are here as a safeguard to make sure future changes to EditableCatalogue
+ * do not unexpectedly mutate the wrapped Catalogue.
  *
  * @see EditableCatalogue
  * @see Catalogue

--- a/soundboard/src/test/java/editor/model/EditableGroupTest.java
+++ b/soundboard/src/test/java/editor/model/EditableGroupTest.java
@@ -98,7 +98,7 @@ class EditableGroupTest {
         assertFalse(editableGroup.isMarkedForRemoval(playlist));
 
         editableGroup.saveChanges();
-        assertEquals(0, playlist.size());
+        assertEquals(0, group.size());
     }
 
     @Test

--- a/soundboard/src/test/java/editor/model/EditableGroupTest.java
+++ b/soundboard/src/test/java/editor/model/EditableGroupTest.java
@@ -1,0 +1,88 @@
+package editor.model;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import soundboard.model.catalogue.Group;
+import soundboard.model.catalogue.Playlist;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Confirm the EditableGroup only mutates the wrapped Group.
+ * when requested.
+ *
+ * @see EditableGroup
+ * @see Group
+ */
+class EditableGroupTest {
+
+    Group group;
+    EditableGroup editableGroup;
+    Playlist playlist;
+
+    @BeforeEach
+    void setUp() {
+        group = new Group("test");
+        editableGroup = new EditableGroup(group);
+        playlist = new Playlist("mock");
+    }
+
+    @Test
+    void addPlaylist() {
+        editableGroup.addPlaylist(playlist);
+        assertEquals(0, group.size());
+
+        editableGroup.saveChanges();
+        assertEquals(1, group.size());
+
+        editableGroup.saveChanges();
+        assertEquals(1, group.size(), "Changes should only be saved once.");
+    }
+
+    @Test
+    void removePlaylist() {
+        group.add(playlist);
+
+        editableGroup.removePlaylist(playlist);
+        assertEquals(1, group.size());
+
+        editableGroup.saveChanges();
+        assertEquals(0, group.size(), "Changes should only be saved once.");
+
+        editableGroup.saveChanges();
+        assertEquals(0, group.size(), "Changes should only be saved once.");
+    }
+
+    @Test
+    void updateTitle() {
+        editableGroup.updateTitle("dummy");
+        assertEquals("test", group.getName());
+
+        editableGroup.saveChanges();
+        assertEquals("dummy", group.getName());
+
+        editableGroup.updateTitle("foo");
+        editableGroup.clearChanges();
+        assertEquals("dummy", group.getName());
+    }
+
+    @Test
+    void isRecentlyAdded() {
+        assertFalse(editableGroup.isRecentlyAdded(playlist));
+        editableGroup.addPlaylist(playlist);
+        assertTrue(editableGroup.isRecentlyAdded(playlist));
+
+        editableGroup.clearChanges();
+        assertFalse(editableGroup.isRecentlyAdded(playlist));
+    }
+
+    @Test
+    void isMarkedForRemoval() {
+        assertFalse(editableGroup.isMarkedForRemoval(playlist));
+        editableGroup.removePlaylist(playlist);
+        assertTrue(editableGroup.isMarkedForRemoval(playlist));
+
+        editableGroup.clearChanges();
+        assertFalse(editableGroup.isMarkedForRemoval(playlist));
+    }
+}

--- a/soundboard/src/test/java/editor/model/EditableGroupTest.java
+++ b/soundboard/src/test/java/editor/model/EditableGroupTest.java
@@ -47,7 +47,7 @@ class EditableGroupTest {
         assertEquals(1, group.size());
 
         editableGroup.saveChanges();
-        assertEquals(0, group.size(), "Changes should only be saved once.");
+        assertEquals(0, group.size());
 
         editableGroup.saveChanges();
         assertEquals(0, group.size(), "Changes should only be saved once.");

--- a/soundboard/src/test/java/editor/model/EditableGroupTest.java
+++ b/soundboard/src/test/java/editor/model/EditableGroupTest.java
@@ -88,4 +88,29 @@ class EditableGroupTest {
         editableGroup.clearChanges();
         assertFalse(editableGroup.isMarkedForRemoval(playlist));
     }
+
+    @Test
+    void undoAddPlaylist() {
+        editableGroup.addPlaylist(playlist);
+        editableGroup.undoAddPlaylist(playlist);
+
+        assertFalse(editableGroup.isRecentlyAdded(playlist));
+        assertFalse(editableGroup.isMarkedForRemoval(playlist));
+
+        editableGroup.saveChanges();
+        assertEquals(0, playlist.size());
+    }
+
+    @Test
+    void undoRemovePlaylist() {
+        group.add(playlist);
+
+        editableGroup.removePlaylist(playlist);
+        editableGroup.undoRemovePlaylist(playlist);
+        assertFalse(editableGroup.isRecentlyAdded(playlist));
+        assertFalse(editableGroup.isMarkedForRemoval(playlist));
+
+        editableGroup.saveChanges();
+        assertEquals(1, group.size());
+    }
 }

--- a/soundboard/src/test/java/editor/model/EditableGroupTest.java
+++ b/soundboard/src/test/java/editor/model/EditableGroupTest.java
@@ -8,8 +8,11 @@ import soundboard.model.catalogue.Playlist;
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
- * Confirm the EditableGroup only mutates the wrapped Group.
- * when requested.
+ * Confirm the EditableGroup only mutates the wrapped Group when requested.
+ * <br><br>
+ * Implementation of EditableGroup is simple, and these tests are very basic.
+ * They are here as a safeguard to make sure future changes to EditableGroup
+ * do not unexpectedly mutate the wrapped Group.
  *
  * @see EditableGroup
  * @see Group

--- a/soundboard/src/test/java/editor/model/EditablePlaylistTest.java
+++ b/soundboard/src/test/java/editor/model/EditablePlaylistTest.java
@@ -1,9 +1,10 @@
 package editor.model;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import soundboard.model.catalogue.Playlist;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Confirm the EditablePlaylist only mutates the wrapped Playlist
@@ -14,11 +15,17 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  */
 class EditablePlaylistTest {
 
+    Playlist playlist;
+    EditablePlaylist editablePlaylist;
+
+    @BeforeEach
+    void setUp() {
+        playlist = new Playlist("dummy");
+        editablePlaylist = new EditablePlaylist(playlist);
+    }
+
     @Test
     void addSongs() {
-        Playlist playlist = new Playlist("dummy");
-        EditablePlaylist editablePlaylist = new EditablePlaylist(playlist);
-
         editablePlaylist.addSong("foo");
         editablePlaylist.addSong("fib");
         editablePlaylist.addSong("fob");
@@ -33,11 +40,9 @@ class EditablePlaylistTest {
 
     @Test
     void removeSongs() {
-        Playlist playlist = new Playlist("dummy");
         playlist.add("foo");
         playlist.add("fib");
         playlist.add("fob");
-        EditablePlaylist editablePlaylist = new EditablePlaylist(playlist);
 
         editablePlaylist.removeSong("foo");
         assertEquals(3, playlist.size());
@@ -57,9 +62,6 @@ class EditablePlaylistTest {
 
     @Test
     void updateTitle() {
-        Playlist playlist = new Playlist("dummy");
-        EditablePlaylist editablePlaylist = new EditablePlaylist(playlist);
-
         editablePlaylist.updateTitle("test");
         assertEquals("dummy", playlist.getTitle());
 
@@ -69,5 +71,25 @@ class EditablePlaylistTest {
         editablePlaylist.updateTitle("foo");
         editablePlaylist.clearChanges();
         assertEquals("test", playlist.getTitle());
+    }
+
+    @Test
+    void isMarkedForRemoval() {
+        assertFalse(editablePlaylist.isMarkedForRemoval("foo"));
+        editablePlaylist.removeSong("foo");
+        assertTrue(editablePlaylist.isMarkedForRemoval("foo"));
+
+        editablePlaylist.clearChanges();
+        assertFalse(editablePlaylist.isMarkedForRemoval("foo"));
+    }
+
+    @Test
+    void isRecentlyAdded() {
+        assertFalse(editablePlaylist.isRecentlyAdded("foo"));
+        editablePlaylist.addSong("foo");
+        assertTrue(editablePlaylist.isRecentlyAdded("foo"));
+
+        editablePlaylist.clearChanges();
+        assertFalse(editablePlaylist.isRecentlyAdded("foo"));
     }
 }

--- a/soundboard/src/test/java/editor/model/EditablePlaylistTest.java
+++ b/soundboard/src/test/java/editor/model/EditablePlaylistTest.java
@@ -97,18 +97,26 @@ class EditablePlaylistTest {
     }
 
     @Test
-    void addRemoveSong() {
+    void undoAddSong() {
         editablePlaylist.addSong("foo");
         editablePlaylist.removeSong("foo");
+
+        assertFalse(editablePlaylist.isRecentlyAdded("foo"));
+        assertFalse(editablePlaylist.isMarkedForRemoval("foo"));
+
         editablePlaylist.saveChanges();
         assertEquals(0, playlist.size());
     }
 
     @Test
-    void addRemoveSongNameClash() {
+    void undoAddSongNameClash() {
         playlist.add("foo");
+
         editablePlaylist.addSong("foo");
         editablePlaylist.removeSong("foo");
+        assertFalse(editablePlaylist.isRecentlyAdded("foo"));
+        assertFalse(editablePlaylist.isMarkedForRemoval("foo"));
+
         editablePlaylist.saveChanges();
         assertEquals(1, playlist.size());
     }
@@ -116,8 +124,12 @@ class EditablePlaylistTest {
     @Test
     void undoRemoveSong() {
         playlist.add("foo");
+
         editablePlaylist.removeSong("foo");
         editablePlaylist.addSong("foo");
+        assertFalse(editablePlaylist.isRecentlyAdded("foo"));
+        assertFalse(editablePlaylist.isMarkedForRemoval("foo"));
+
         editablePlaylist.saveChanges();
         assertEquals(1, playlist.size());
     }

--- a/soundboard/src/test/java/editor/model/EditablePlaylistTest.java
+++ b/soundboard/src/test/java/editor/model/EditablePlaylistTest.java
@@ -25,7 +25,7 @@ class EditablePlaylistTest {
     }
 
     @Test
-    void addSongs() {
+    void addSong() {
         editablePlaylist.addSong("foo");
         editablePlaylist.addSong("fib");
         editablePlaylist.addSong("fob");
@@ -39,7 +39,7 @@ class EditablePlaylistTest {
     }
 
     @Test
-    void removeSongs() {
+    void removeSong() {
         playlist.add("foo");
         playlist.add("fib");
         playlist.add("fob");
@@ -74,16 +74,6 @@ class EditablePlaylistTest {
     }
 
     @Test
-    void isMarkedForRemoval() {
-        assertFalse(editablePlaylist.isMarkedForRemoval("foo"));
-        editablePlaylist.removeSong("foo");
-        assertTrue(editablePlaylist.isMarkedForRemoval("foo"));
-
-        editablePlaylist.clearChanges();
-        assertFalse(editablePlaylist.isMarkedForRemoval("foo"));
-    }
-
-    @Test
     void isRecentlyAdded() {
         assertFalse(editablePlaylist.isRecentlyAdded("foo"));
         editablePlaylist.addSong("foo");
@@ -91,5 +81,15 @@ class EditablePlaylistTest {
 
         editablePlaylist.clearChanges();
         assertFalse(editablePlaylist.isRecentlyAdded("foo"));
+    }
+
+    @Test
+    void isMarkedForRemoval() {
+        assertFalse(editablePlaylist.isMarkedForRemoval("foo"));
+        editablePlaylist.removeSong("foo");
+        assertTrue(editablePlaylist.isMarkedForRemoval("foo"));
+
+        editablePlaylist.clearChanges();
+        assertFalse(editablePlaylist.isMarkedForRemoval("foo"));
     }
 }

--- a/soundboard/src/test/java/editor/model/EditablePlaylistTest.java
+++ b/soundboard/src/test/java/editor/model/EditablePlaylistTest.java
@@ -7,8 +7,11 @@ import soundboard.model.catalogue.Playlist;
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
- * Confirm the EditablePlaylist only mutates the wrapped Playlist
- * when requested.
+ * Confirm the EditablePlaylist only mutates the wrapped Playlist when requested.
+ * <br><br>
+ * Implementation of EditablePlaylist is simple, and these tests are very basic.
+ * They are here as a safeguard to make sure future changes to EditablePlaylist
+ * do not unexpectedly mutate the wrapped Playlist.
  *
  * @see EditablePlaylist
  * @see Playlist

--- a/soundboard/src/test/java/editor/model/EditablePlaylistTest.java
+++ b/soundboard/src/test/java/editor/model/EditablePlaylistTest.java
@@ -99,7 +99,7 @@ class EditablePlaylistTest {
     @Test
     void undoAddSong() {
         editablePlaylist.addSong("foo");
-        editablePlaylist.removeSong("foo");
+        editablePlaylist.undoAddSong("foo");
 
         assertFalse(editablePlaylist.isRecentlyAdded("foo"));
         assertFalse(editablePlaylist.isMarkedForRemoval("foo"));
@@ -113,7 +113,7 @@ class EditablePlaylistTest {
         playlist.add("foo");
 
         editablePlaylist.addSong("foo");
-        editablePlaylist.removeSong("foo");
+        editablePlaylist.undoAddSong("foo");
         assertFalse(editablePlaylist.isRecentlyAdded("foo"));
         assertFalse(editablePlaylist.isMarkedForRemoval("foo"));
 
@@ -126,7 +126,7 @@ class EditablePlaylistTest {
         playlist.add("foo");
 
         editablePlaylist.removeSong("foo");
-        editablePlaylist.addSong("foo");
+        editablePlaylist.undoRemoveSong("foo");
         assertFalse(editablePlaylist.isRecentlyAdded("foo"));
         assertFalse(editablePlaylist.isMarkedForRemoval("foo"));
 

--- a/soundboard/src/test/java/editor/model/EditablePlaylistTest.java
+++ b/soundboard/src/test/java/editor/model/EditablePlaylistTest.java
@@ -95,4 +95,30 @@ class EditablePlaylistTest {
         editablePlaylist.clearChanges();
         assertFalse(editablePlaylist.isMarkedForRemoval("foo"));
     }
+
+    @Test
+    void addRemoveSong() {
+        editablePlaylist.addSong("foo");
+        editablePlaylist.removeSong("foo");
+        editablePlaylist.saveChanges();
+        assertEquals(0, playlist.size());
+    }
+
+    @Test
+    void addRemoveSongNameClash() {
+        playlist.add("foo");
+        editablePlaylist.addSong("foo");
+        editablePlaylist.removeSong("foo");
+        editablePlaylist.saveChanges();
+        assertEquals(1, playlist.size());
+    }
+
+    @Test
+    void undoRemoveSong() {
+        playlist.add("foo");
+        editablePlaylist.removeSong("foo");
+        editablePlaylist.addSong("foo");
+        editablePlaylist.saveChanges();
+        assertEquals(1, playlist.size());
+    }
 }

--- a/soundboard/src/test/java/editor/model/EditablePlaylistTest.java
+++ b/soundboard/src/test/java/editor/model/EditablePlaylistTest.java
@@ -1,0 +1,73 @@
+package editor.model;
+
+import org.junit.jupiter.api.Test;
+import soundboard.model.catalogue.Playlist;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Confirm the EditablePlaylist only mutates the wrapped Playlist
+ * when requested.
+ *
+ * @see EditablePlaylist
+ * @see Playlist
+ */
+class EditablePlaylistTest {
+
+    @Test
+    void addSongs() {
+        Playlist playlist = new Playlist("dummy");
+        EditablePlaylist editablePlaylist = new EditablePlaylist(playlist);
+
+        editablePlaylist.addSong("foo");
+        editablePlaylist.addSong("fib");
+        editablePlaylist.addSong("fob");
+        assertEquals(0, playlist.size(), "Playlist should be empty before saved changes.");
+
+        editablePlaylist.saveChanges();
+        assertEquals(3, playlist.size(), "Playlist should have 3 elements after saved changes.");
+
+        editablePlaylist.saveChanges();
+        assertEquals(3, playlist.size(), "Playlist should still have 3 elements.");
+    }
+
+    @Test
+    void removeSongs() {
+        Playlist playlist = new Playlist("dummy");
+        playlist.add("foo");
+        playlist.add("fib");
+        playlist.add("fob");
+        EditablePlaylist editablePlaylist = new EditablePlaylist(playlist);
+
+        editablePlaylist.removeSong("foo");
+        assertEquals(3, playlist.size());
+
+        editablePlaylist.saveChanges();
+        assertEquals(2, playlist.size());
+
+        editablePlaylist.removeSong("foo");
+        editablePlaylist.saveChanges();
+        assertEquals(2, playlist.size());
+
+        editablePlaylist.removeSong("fib");
+        editablePlaylist.removeSong("fob");
+        editablePlaylist.clearChanges();
+        assertEquals(2, playlist.size());
+    }
+
+    @Test
+    void updateTitle() {
+        Playlist playlist = new Playlist("dummy");
+        EditablePlaylist editablePlaylist = new EditablePlaylist(playlist);
+
+        editablePlaylist.updateTitle("test");
+        assertEquals("dummy", playlist.getTitle());
+
+        editablePlaylist.saveChanges();
+        assertEquals("test", playlist.getTitle());
+
+        editablePlaylist.updateTitle("foo");
+        editablePlaylist.clearChanges();
+        assertEquals("test", playlist.getTitle());
+    }
+}


### PR DESCRIPTION
Defined data model for the CatalogueEditor.

- added JUnit dependency for testing.
- updated `soundboard.model`: changed class constructors visibilities to public, added missing accessor methods.