### PR TITLE
extend Playlist from `ArrayList`

### DIFF
--- a/soundboard/src/main/java/soundboard/model/catalogue/Playlist.java
+++ b/soundboard/src/main/java/soundboard/model/catalogue/Playlist.java
@@ -5,10 +5,16 @@ import com.fasterxml.jackson.databind.JsonNode;
 import java.util.ArrayList;
 
 /**
- * A Playlist represents a collection of songs.
- * Specifically, YouTube URL to songs for the discord bot to play from.
- * In the future, this may expand to additional services such as Deezer,
- * Spotify, or local songs.
+ * Represents a collection of songs.
+ * <br><br>
+ * Specifically, YouTube URLs to songs.
+ * These URLs are sent to the Bot service where they are used to retrieve
+ * audio sources to stream into a Discord Voice Channel.
+ * <br><br>
+ * In the future, the Bot may expand to additional services such as Deezer,
+ * Spotify, or local songs. In which case this Playlist will store
+ * Song objects that contain URLs and the name of the service the URL points to
+ * so that the Bot can know how to handle retrieving the audio source at that URL.
  */
 public class Playlist extends ArrayList<String> {
 
@@ -18,6 +24,10 @@ public class Playlist extends ArrayList<String> {
         this.title = title;
     }
 
+    /**
+     * @param json Node representing a Playlist.
+     * @return Playlist constructed from the contents of a JSON node.
+     */
     public static Playlist fromJson(JsonNode json) {
         Playlist playlist = new Playlist(json.get("Title").asText());
         for (JsonNode song : json.get("Songs")) playlist.add(song.asText());

--- a/soundboard/src/main/java/soundboard/model/catalogue/Playlist.java
+++ b/soundboard/src/main/java/soundboard/model/catalogue/Playlist.java
@@ -2,7 +2,7 @@ package soundboard.model.catalogue;
 
 import com.fasterxml.jackson.databind.JsonNode;
 
-import java.util.HashSet;
+import java.util.ArrayList;
 
 /**
  * A Playlist represents a collection of songs.
@@ -10,7 +10,7 @@ import java.util.HashSet;
  * In the future, this may expand to additional services such as Deezer,
  * Spotify, or local songs.
  */
-public class Playlist extends HashSet<String> {
+public class Playlist extends ArrayList<String> {
 
     private final String title;
 


### PR DESCRIPTION
Playlist was previously extended from `HashSet` to conviently remove duplicate songs that may have been copied in when building the raw `catalogue.json` file. This had the drawback of not preserving the ordering and exact contents of a Playlist, which might want to have duplicate songs or to be played in a specific order.